### PR TITLE
kable_table_one caption

### DIFF
--- a/R/table_one.R
+++ b/R/table_one.R
@@ -307,7 +307,7 @@ table_one <- function(df, group, datadic = NULL, var_name, var_desp, seed = 123,
 #' @importFrom magrittr %>%
 #' @export
 
-kable_table_one <- function(tableone,caption = NULL,bold_variables = TRUE,full_width = TRUE){
+kable_table_one <- function(tableone,caption = "", bold_variables = TRUE,full_width = TRUE){
 
   out = tableone$tab
   pval = tableone$pval


### PR DESCRIPTION
use caption = "", in the kable_table_one() function, and tested it already, table number is working even without specify the caption.